### PR TITLE
modifies at-rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# CHANGELOG
+## 2.0.0 - 2019-09-06
+Adds the possibility to group statements like `@import` in css files.
+```javascript
+[...]
+"at-rule-empty-line-before": [ "always", {
+      except: [ "after-same-name" ],
+    } ],
+[...]
+```

--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
 module.exports = {
   plugins: ["stylelint-order"],
   rules: {
-    "at-rule-empty-line-before": "always",
+    "at-rule-empty-line-before": [ "always", {
+      except: [ "after-same-name" ],
+    } ],
     "at-rule-semicolon-newline-after": "always",
     "order/properties-order": [
       {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fewlines/stylelint-config-fewlines-css",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "Shareable config for Stylelint used by Fewlines",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
This PR modifies the `at-rule` property to allows this type of declaration

## Description

This modification allows this type of statements

```
@import .....
@import .....
```
documentation: https://github.com/fewlinesco/stylelint-config-fewlines-css/pull/new/improve-at-rule

## Related Issue

[ch654]

## Motivation and Context

I'd like to group `@statements` like import at the top of css files.

## How Has This Been Tested?

I tried in developpers-portal by changing it directly in node_modules then copy/paste the code in fewlines-css

## Types of changes

- Chore (non-breaking change which refactors / improves the existing code base)
- ~Bug fix (non-breaking change which fixes an issue)~
- ~New feature (non-breaking change which adds functionality)~
- ~Breaking change (fix or feature that would cause existing functionality to change)~

## Checklist:

- ✅ My code follows the code style of this project.
- ✅ My change requires a change to the documentation.
- ✅ I have updated the documentation accordingly.
- 🔴 I have added tests to cover my changes.
- ✅ All new and existing tests passed.